### PR TITLE
Fixed timeout handling in recv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README_RST = os.path.join(HERE, 'README.rst')
 
 setup(
     name='xmodem',
-    version='0.4.6',
+    version='0.4.7',
     author='Wijnand Modderman, Jeff Quast, Kris Hardy',
     author_email='maze@pyth0n.org',
     description=('XMODEM protocol implementation.'),

--- a/xmodem/__init__.py
+++ b/xmodem/__init__.py
@@ -507,6 +507,8 @@ class XMODEM(object):
                                       retry)
                         self.abort()
                         return None
+                    else: # receive next character
+                        char = self.getc(1, timeout)
 
             # read sequence
             error_count = 0


### PR DESCRIPTION
In recv method, when timeout occurrs during reading of first byte of next packet header, the retry loop was not receiving next character thus rechecking the same value until aborting. With this change, a next character will be retrieved when retrying